### PR TITLE
Remove IS_TLS_ENABLED deprecation from the Mailer config and add helo hostname 

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -260,7 +260,6 @@ spec:
   giteaMailerPort: 465
   giteaMailerUser: gmail-user@gmail.com
   giteaMailerPassword: gmail-user-app-specific-password
-  giteaMailerTls: true
   giteaMailerHeloHostname: example.com
   giteaRegisterEmailConfirm: true
   giteaEnableNotifyMail: true
@@ -619,10 +618,7 @@ giteaMailerHost:
   type: string
 giteaMailerPort:
   description: 'Port of the e-mail server to be used. Default: ""'
-  type: string
-giteaMailerTls:
-  description: 'Use TLS encryption when connecting to the mailer host. Default: true'
-  type: boolean
+  type: integer
 giteaMailerUser:
   description: 'User ID on the e-mail server to use. Frequently the same as the value for giteaMailerFrom. Default: ""'
   type: string

--- a/bundle/manifests/pfe.rhpds.com_gitea.yaml
+++ b/bundle/manifests/pfe.rhpds.com_gitea.yaml
@@ -161,10 +161,6 @@ spec:
                   May need to be an app-specific password if two-factor authentication
                   is enabled on the e-mail server. Default is "".
                 type: string
-              giteaMailerTls:
-                description: Use TLS encryption when connecting to the mailer host.
-                  Default is true.
-                type: boolean
               giteaMailerProtocol:
                 description: Protocol of e-mail provider to be used. Default is smtp.
                 type: string

--- a/config/crd/patches/crd_openapi.yaml
+++ b/config/crd/patches/crd_openapi.yaml
@@ -262,9 +262,6 @@ spec:
               giteaMailerPort:
                 description: Port of the e-mail server to be used. Default is 465.
                 type: integer
-              giteaMailerTls:
-                description: Use TLS encryption when connecting to the mailer host. Default is true.
-                type: boolean
               giteaMailerUser:
                 description: User ID on the e-mail server to use. Frequently the same as the value for giteaMailerFrom. Default is "".
                 type: string

--- a/playbooks/gitea.yml
+++ b/playbooks/gitea.yml
@@ -96,7 +96,6 @@
       _gitea_mailer_protocol: "{{ gitea_mailer_protocol | default('smtps') }}"
       _gitea_mailer_host: "{{ gitea_mailer_host | default('') }}"
       _gitea_mailer_port: "{{ gitea_mailer_port | default(465) }}"
-      _gitea_mailer_tls: "{{ gitea_mailer_tls | default(true) | bool }}"
       _gitea_mailer_user: "{{ gitea_mailer_user | default('') }}"
       _gitea_mailer_password: "{{ gitea_mailer_password | default('') }}"
       _gitea_mailer_helo_hostname: "{{ gitea_mailer_helo_hostname | default ('') }}"

--- a/roles/gitea-ocp/defaults/main.yml
+++ b/roles/gitea-ocp/defaults/main.yml
@@ -95,7 +95,6 @@ _gitea_mailer_from: gitea@mydomain.com
 _gitea_mailer_protocol: smtps
 _gitea_mailer_host: mail.mydomain.com
 _gitea_mailer_port: 465
-_gitea_mailer_tls: true
 _gitea_mailer_user: gitea@mydomain.com
 _gitea_mailer_password: password
 _gitea_mailer_helo_hostname: ""

--- a/roles/gitea-ocp/templates/configmap.yaml.j2
+++ b/roles/gitea-ocp/templates/configmap.yaml.j2
@@ -53,9 +53,9 @@ data:
     PROTOCOL       = {{ _gitea_mailer_protocol }}
     SMTP_ADDR      = {{ _gitea_mailer_host }}
     SMTP_PORT      = {{ _gitea_mailer_port }}
-    IS_TLS_ENABLED = {{ _gitea_mailer_tls | bool }}
     USER           = {{ _gitea_mailer_user }}
     PASSWD         = `{{ _gitea_mailer_password }}`
+    HELO_HOSTNAME  = {{ _gitea_mailer_helo_hostname }}
 
     [service]
     REGISTER_EMAIL_CONFIRM            = {{ _gitea_register_email_confirm | bool }}


### PR DESCRIPTION
One  more deprecation was found. 

![Screenshot 2023-11-10 at 15 19 03](https://github.com/rhpds/gitea-operator/assets/19761842/5b0322fb-7586-441c-b0e0-327a4d212537)

This fix includes: 

1) Removed the deprecated `IS_TLS_ENABLED` from the Mailer config. 
2) Added `HELO_HOSTNAME` into the Mailer config. 


After testing no more deprecations were found. 

![Screenshot 2023-11-10 at 15 24 08](https://github.com/rhpds/gitea-operator/assets/19761842/858bef4b-dee6-451f-9846-a035302e5dd3)

![Screenshot 2023-11-10 at 15 47 12](https://github.com/rhpds/gitea-operator/assets/19761842/10d2f46d-8422-44ad-b121-38254e96284b)

 