### PR TITLE
Add giteaPackagesPath CR field for persistent package storage

### DIFF
--- a/playbooks/gitea.yml
+++ b/playbooks/gitea.yml
@@ -100,3 +100,4 @@
       _gitea_mailer_helo_hostname: "{{ gitea_mailer_helo_hostname | default('') }}"
       _gitea_register_email_confirm: "{{ gitea_register_email_confirm | default(false) | bool }}"
       _gitea_enable_notify_mail: "{{ gitea_enable_notify_mail | default(false) | bool }}"
+      _gitea_packages_path: "{{ gitea_packages_path | default('') }}"

--- a/roles/gitea-ocp/templates/configmap.yaml.j2
+++ b/roles/gitea-ocp/templates/configmap.yaml.j2
@@ -94,3 +94,9 @@ data:
     FILE_EXTENSIONS = .adoc,.asciidoc
     RENDER_COMMAND = "asciidoc --backend=xhtml11 --no-header-footer --attribute source-highlighter=source-highlight --out-file=- -"
     IS_INPUT_FILE = false
+
+{% if _gitea_packages_path | default("") | length > 0 %}
+    [packages]
+    PATH = {{ _gitea_packages_path }}
+
+{% endif %}


### PR DESCRIPTION
## Problem

Gitea stores packages (Helm charts, npm packages, container images, etc.) at \`/home/gitea/data/packages/\` by default. This path is in the container's ephemeral overlay filesystem — it is **not** on the PVC, which is only mounted at \`/gitea-repositories\` (git repo data).

On any pod restart — from node pressure, OOM eviction, operator upgrade, or routine maintenance — all package registry contents are silently lost. Labs and workflows that publish Helm charts to Gitea's package registry and then \`helm install\` from it will break after the first pod restart.

## Solution

Adds an optional \`giteaPackagesPath\` field to the Gitea CR spec. When set, the operator renders a \`[packages]\` section into the generated \`app.ini\`:

\`\`\`ini
[packages]
PATH = /gitea-repositories/packages
\`\`\`

Setting this to a path on the PVC (e.g. \`/gitea-repositories/packages\`) makes package registry contents persistent across pod restarts and operator reconciliation.

## Changes

- \`playbooks/gitea.yml\`: maps CR field \`giteaPackagesPath\` → \`_gitea_packages_path\` role variable (same pattern as all other CR fields)
- \`roles/gitea-ocp/templates/configmap.yaml.j2\`: renders \`[packages] PATH\` when \`_gitea_packages_path\` is non-empty

## Backward Compatibility

\`_gitea_packages_path\` defaults to empty. When empty, the \`{% if %}\` block does not render and the generated \`app.ini\` is byte-for-byte identical to today's output. No impact on existing deployments.

## Example Usage

\`\`\`yaml
apiVersion: pfe.rhpds.com/v1
kind: Gitea
metadata:
  name: gitea
  namespace: gitea
spec:
  giteaPackagesPath: /gitea-repositories/packages
  # ... other fields
\`\`\`