### PR TITLE
Update to latest SDK image. Breaking change to restructure data on the PVC to support packages.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/ansible-operator:v1.37.2
+FROM quay.io/operator-framework/ansible-operator:v1.42.2
 
 COPY requirements.yml ${HOME}/requirements.yml
 RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \

--- a/roles/gitea-ocp/tasks/migrate_repos.yml
+++ b/roles/gitea-ocp/tasks/migrate_repos.yml
@@ -23,7 +23,6 @@
     force_basic_auth: true
     status_code: 200, 404
   register: r_gitea_repo_exists
-  # ignore_errors: true
 
 - name: Gitea Repository does not exist yet
   when: r_gitea_repo_exists.status == 404

--- a/roles/gitea-ocp/templates/configmap.yaml.j2
+++ b/roles/gitea-ocp/templates/configmap.yaml.j2
@@ -28,7 +28,10 @@ data:
     SSL_MODE = disable
 
     [repository]
-    ROOT = /gitea-repositories
+    ROOT = /gitea-data/repositories
+
+    [packages]
+    PATH = /gitea-data/packages
 
     [server]
     ROOT_URL         = {{ _gitea_actual_route_url }}/

--- a/roles/gitea-ocp/templates/deployment.yaml.j2
+++ b/roles/gitea-ocp/templates/deployment.yaml.j2
@@ -52,12 +52,12 @@ spec:
             cpu: "{{ _gitea_cpu_limit}}"
             memory: "{{ _gitea_memory_limit }}"
         volumeMounts:
-        - name: gitea-repositories
-          mountPath: /gitea-repositories
+        - name: gitea-data
+          mountPath: /gitea-data
         - name: gitea-config
           mountPath: /home/gitea/conf-import
       volumes:
-      - name: gitea-repositories
+      - name: gitea-data
         persistentVolumeClaim:
           claimName: "{{ _gitea_name }}-pvc"
       - name: gitea-config


### PR DESCRIPTION
Update to Ansible Operator SDK image 1.42.2 (latest as of now).

Update storage on the PVC from /gitea-repositories to /gitea-data/repositories and add /gitea-data/packages.

This is a change that will break existing installations.
